### PR TITLE
fix for issue #1: neomgr couldn't display new registrations.

### DIFF
--- a/Neoloader/init.lua
+++ b/Neoloader/init.lua
@@ -418,6 +418,12 @@ function lib.register(iniFilePointer)
 		end
 		
 		--don't mark plugin version as latest, it won't be "activated"
+		if not neo.plugin_registry[id] then
+			neo.plugin_registry[id] = {
+				latest = "0",
+			}
+		end
+		table.insert(neo.plugin_registry[id], data.plugin_version)
 		
 		lib.log_error("Added NEW " .. id .. " v" .. (data.plugin_version or "0") .. " to Neoloader's plugin registry and to config.ini at position " .. tostring(neo.number_plugins_registered))
 		lib.notify("NEW_REGISTRY", id, data.plugin_version or "0")


### PR DESCRIPTION
neomgr couldn't get data on new registrations; lib.register() didn't create the redirect table, which caused lib.is_exist() to fail, which caused lib.get_state() to fail.