### PR TITLE
Working directory

### DIFF
--- a/Neoloader/env.lua
+++ b/Neoloader/env.lua
@@ -1,32 +1,27 @@
 --[[
-This file contains the base "environment" that is normally set up by the default interface.
+This file contains the base "environment" of functions and variables that is normally set up by the default interface.
 These functions and variables are often required for certain functions or plugins to run, so we need to create them ourselves in the meantime.
 Most of these were ripped from Draugath's BarebonesIF interface replacer - thanks, Draugath!
-
-If you want to prevent the iup_templates from loading, add "rLoadTemplates=NO" to config.ini or config_overrides.ini under [Neoloader].
-DO NOT do this unless you are using a custom interface that provides its own templates.
-
->>>>Not yet implemented, probably wont because it might be problematic to support.
 ]]--
 
 
 
 
-function HUDSize(x, y)
+HUDSize = HUDSize or function(x, y)
 	local xres = gkinterface.GetXResolution()
 	local yres = gkinterface.GetYResolution()
 	return string.format("%sx%s", x and math.floor(x * xres) or "", y and "%"..math.floor(y * 100) or "")
 end
 
-function GetFriendlyStatus()
+GetFriendlyStatus = GetFriendlyStatus or function()
 	return 1
 end
 
-function HideDialog(dlg) 
+HideDialog = HideDialog or function(dlg) 
 	dlg:hide() 
 end
 
-function ShowDialog(dlg, x, y)
+ShowDialog = ShowDialog or function(dlg, x, y)
 	if x then
 		dlg:showxy(x, y) 
 	else 
@@ -34,11 +29,11 @@ function ShowDialog(dlg, x, y)
 	end 
 end
 
-function PopupDialog(dlg, x, y) --depreciated!
+PopupDialog = PopupDialog or function(dlg, x, y) --depreciated!
 	ShowDialog(dlg, x, y)
 end
 
-function CreditAndCrystal(in1, in2, in3, in4, in5)
+CreditAndCrystal = CreditAndCrystal or function(in1, in2, in3, in4, in5)
 	print(type(in1) .. ">" .. tostring(in1))
 	print(type(in2) .. ">" .. tostring(in2))
 	print(type(in3) .. ">" .. tostring(in3))
@@ -47,7 +42,7 @@ function CreditAndCrystal(in1, in2, in3, in4, in5)
 	return 1
 end
 
-function OpenAlarm(title, text, buttontext)
+OpenAlarm = OpenAlarm or function(title, text, buttontext)
 	PopupDialog(iup.dialog{
 		iup.vbox{
 			iup.label{title = title.."\n"..text},
@@ -67,24 +62,24 @@ function OpenAlarm(title, text, buttontext)
 	}, iup.CENTER, iup.CENTER)
 end
 
-IF_DIR = 'vo/'
-IMAGE_DIR = gkini.ReadString("Vendetta", "skin", "images/station/")
-tabseltextcolor = "1 241 255"
-tabunseltextcolor = "0 185 199"
+IF_DIR = IF_DIR or 'vo/'
+IMAGE_DIR = IMAGE_DIR or gkini.ReadString("Vendetta", "skin", "images/station/")
+tabseltextcolor = tabseltextcolor or "1 241 255"
+tabunseltextcolor = tabunseltextcolor or "0 185 199"
 
-defaultedittextcolor = "255 255 255"
-listboxbordercolor = "0 0 0"
-listboxfocusedbordercolor = "0 0 0"
-buttondisabledcolor = "127 127 127"
-textlistboxselcolor = "127 127 127"
-textlistboxunfocusedselcolor = "0 0 0"
-UseCondensedUI = "false"
-defaulttextcolor = "255 255 255"
+defaultedittextcolor = defaultedittextcolor or "255 255 255"
+listboxbordercolor = listboxbordercolor or "0 0 0"
+listboxfocusedbordercolor = listboxfocusedbordercolor or "0 0 0"
+buttondisabledcolor = buttondisabledcolor or "127 127 127"
+textlistboxselcolor = textlistboxselcolor or "127 127 127"
+textlistboxunfocusedselcolor = textlistboxunfocusedselcolor or "0 0 0"
+UseCondensedUI = UseCondensedUI or "false"
+defaulttextcolor = defaulttextcolor or "255 255 255"
 
 dofile('vo/if_fontsize.lua')
 dofile('vo/if_templates.lua')
 
-FactionColor_RGB = { --these should be changed so every faction is properly represented by their color
+FactionColor_RGB = FactionColor_RGB or { --these should be changed so every faction is properly represented by their color
 	[0] = "212 212 212",--unaligned
 	[1] = "96 128 255", --itani
 	[2] = "255 32 32", --serco

--- a/Neoloader/init.lua
+++ b/Neoloader/init.lua
@@ -68,8 +68,8 @@ end
 neo = {
 	version = {
 		[1] = 5,
-		[2] = 1,
-		[3] = 2,
+		[2] = 2,
+		[3] = 0,
 		[4] = "Beta",
 	},
 	notifications = {},

--- a/Neoloader/main.lua
+++ b/Neoloader/main.lua
@@ -8,6 +8,11 @@ local function newloader()
 	UnregisterUserCommand("neosetup")
 	cp("Neoloader appears to be setting up for the first time")
 	cp("VO will restart with Neoloader momentarily...")
+	local prev_if = gkini.ReadString("Vendetta", "if", "")
+	if prev_if ~= "" and prev_if ~= "vo/if.lua" then
+		cp("A custom interface was already being used! This has been backed up to ['Vendetta', 'if2']")
+		gkini.WriteString("Vendetta", "if2", prev_if)
+	end
 	gkini.WriteString("Vendetta", "if", "plugins/Neoloader/init.lua")
 	gkini.WriteInt("Neoloader", "Init", 0)
 	RegisterEvent(ReloadInterface, "START")--if someone starts the game, reloads are ignored until this event is fired, so we reg one here.
@@ -16,8 +21,13 @@ local function newloader()
 end
 
 if type(lib) ~= "table" or type(lib[1]) ~= "string" then
+	local prev_if = gkini.ReadString("Vendetta", "if", "")
 	if gkini.ReadString("Neoloader", "uninstalled", "NO") == "NO" and gkini.ReadInt("Vendetta", "Init", 0) == 0 then
 		newloader()
+	elseif prev_if ~= "vo/if.lua" and prev_if ~= "" then
+		cp("You are running a custom interface! Neoloader installation must be manually triggered with /neosetup")
+		cp("Run the setup, and then make your own configurations afterwards. Your IF will be saved as if2 in the config.")
+		RegisterUserCommand("neosetup", newloader)
 	else
 		cp("Neoloader appears to have been uninstalled recently, but is still in your game's plugins. If you have installed a new version of Neoloader or wish to run it again, use /neosetup")
 		RegisterUserCommand("neosetup", newloader)

--- a/Neoloader/setup.lua
+++ b/Neoloader/setup.lua
@@ -56,6 +56,44 @@ if NEO_UNINSTALL == false then
 			dropdown = "YES",
 		}
 		
+		local obj2flag = false
+		local obj2 = iup.hbox { }
+		local obj3flag = false
+		local obj3 = iup.hbox { }
+		
+		
+		
+		local prev_if = gkini.ReadString("Vendetta", "if2", "")
+		if prev_if ~= "" and gksys.IsExist(prev_if) then
+			obj3flag = true
+			
+			local setting_loader = iup.list {
+				[1] = "plugins/Neoloader/init.lua",
+				[2] = prev_if,
+				value = 1,
+				dropdown = "YES",
+			}
+			
+			obj3 = iup.vbox {
+				iup.fill {
+					size = "%2",
+				},
+				iup.label {
+					title = "You already have a custom interface.",
+				},
+				iup.hbox {
+					iup.label {
+						title = "Please select the one to load:",
+					},
+					setting_loader,
+				},
+			}
+			
+			function obj3.get_val()
+				return setting_loader.value
+			end
+		end
+		
 		local diag = iup.dialog {
 			topmost = "YES",
 			fullscreen = "YES",
@@ -81,31 +119,31 @@ if NEO_UNINSTALL == false then
 								},
 								setting_new_loadstate,
 							},
-							iup.hbox {
-								iup.label {
-									title = "",
-								},
-								--obj
-							},
-							iup.hbox {
-								iup.label {
-									title = "",
-								},
-								--obj
-							},
+							obj2,
+							obj3,
 							iup.button {
 								title = "OK",
 								action = function()
 									if setting_new_loadstate.value == "1" then
 										gkini.WriteString("Neoloader", "rDefaultLoadState", "YES")
 										local pluginlist = lib.get_gstate().pluginlist
+										console_print("[SETUP] Setting default states for")
 										for k, v in ipairs(pluginlist) do
-											console_print("v1 " .. v[1] .. "   v2 " .. v[2])
+											console_print("	" .. v[1] .. "	v" .. v[2])
 											gkini.WriteString("Neo-pluginstate", v[1] .. "." .. v[2], "YES")
 										end
 									end
 									--obj
-									--obj
+									if obj3flag == true then
+										local if_val = obj3.get_val()
+										if if_val == '2' then
+											if_val = prev_if 
+										else
+											if_val = "plugins/Neoloader/init.lua"
+										end
+										console_print("[SETUP] IF selected: " .. if_val)
+										gkini.WriteString("Vendetta", "if", if_val)
+									end
 									gkinterface.GKSaveCfg()
 									ReloadInterface()
 								end,


### PR DESCRIPTION
Contains fixes to Neoloader design relevant to being launched by an external program, such as Draugath's utilities, and improves environment creation in case preload.lua creates its own functions that compete with env.lua.

env.lua now only creates functions if they don't already exist
main.lua setup period doesn't overwrite if= permanently; if= will be saved, and after setup, the user can select to restore it (if it wasn't vo/if.lua or nil)

no LME updates; LME version remains 3.5.0
Neoloader updated to 5.2.0