### PR TITLE
CCD1 viewer in public class

### DIFF
--- a/Neoloader/config_override.ini
+++ b/Neoloader/config_override.ini
@@ -1,9 +1,25 @@
 [Override]
 doOverride=NO
 
-#Change doOverride to YES and create values below to force them in-game
+#Change doOverride to YES and edit/uncomment values below to force them in-game
 #Most values in the [Neoloader] section of your config can be put here.
 #Remember this only affects Neoloader during initialization! mid-game changes can still occur
 
 [Neoloader]
 #your overridden values go here
+#uncomment an option and set the value as preferred.
+
+#ignoreOverrideState=NO
+#allowDelayedLoad=NO
+#allowBadAPIVersion=NO
+#echoLogging=YES
+#defaultLoadState=NO
+#doErrPopup=NO
+#protectResolveFile=YES
+#listPresorted=NO
+#clearCommands=NO
+#dbgFormatting=YES
+#dbgIgnoreLevel=0
+#current_if=
+#current_mgr=neomgr
+#current_notif=neonotif

--- a/Neoloader/init.lua
+++ b/Neoloader/init.lua
@@ -68,11 +68,11 @@ end
 
 
 --This will be local when released
-neo = {
+local neo = {
 	version = {
-		strver = "6.1.0",
+		strver = "6.2.0",
 		[1] = 6,
-		[2] = 1,
+		[2] = 2,
 		[3] = 0,
 		[4] = "",
 	},

--- a/Neoloader/init.lua
+++ b/Neoloader/init.lua
@@ -1651,7 +1651,7 @@ if neo.update_check < 1 then
 		end
 
 		neo.update_check = 1
-		gkini.WriteInt("Neoloader", "update_check", 1)
+		gkini.WriteInt("Neoloader", "iUpdateCheck", 1)
 	end
 end
 

--- a/Neoloader/init.lua
+++ b/Neoloader/init.lua
@@ -1583,9 +1583,7 @@ do
 	
 	for i, filepath in ipairs {
 		"config_override.ini",
-		"neomgr.ini",
 		"neomgr2.lua",
-		"neo_notif.ini",
 		"neo_notif.lua",
 	} do
 		if not gksys.IsExist("plugins/Neoloader/" .. filepath) then

--- a/Neoloader/init.lua
+++ b/Neoloader/init.lua
@@ -118,13 +118,15 @@ local neo = {
 	current_if = gkreadstr("Neoloader", "if", ""),
 	current_mgr = gkreadstr("Neoloader", "mgr", ""),
 	current_notif = gkreadstr("Neoloader", "current_notif", ""),
+
+	update_check = gkini.ReadInt("Neoloader", "iUpdateCheck", 0),
 }
 
 if neo.ignoreOverrideState == "NO" and gkini.ReadInt("Vendetta", "plugins", 1) == 0 then
 	console_print("Plugins are disabled, and Neoloader is not configured to override this setting! The default interface will load, and Neoloader will exit!")
 	dofile("vo/if.lua")
 	return
-end
+end		
 
 local configd = {
 	--config defines
@@ -1622,6 +1624,35 @@ lib.log_error("[timestat] library extra environment setup: " .. tostring(timesta
 if neo.init ~= neo.API then
 	lib.log_error("Neoloader was updated! API was " .. tostring(neo.init), 3)
 	lib.log_error("If Neoloader becomes unstable, use the recovery environment to uninstall, then reinstall!")
+end
+
+--update check
+if neo.update_check < 1 then
+	if neo.update_check == 0 then --Update pre-existing config from Neoloader 6.1.x -> 6.2.0
+		lib.log_error("Neoloader was updated from v6.1.x or earlier - applying configuration fixes for v6.2.0", 3)
+		
+		local registry_fixes = {
+			["plugins/Neoloader/neomgr.ini"] = "plugins/Neoloader/neomgr2.lua",
+			["plugins/Neoloader/neo_notif.ini"] = "plugins/Neoloader/neo_notif.lua",
+		}
+
+		local counter = 0
+		while true do
+			counter = counter + 1
+			local reg = gkini.ReadString("Neo-registry", "reg" .. tostring(counter), "")
+			if reg == "" then
+				break
+			end
+
+			if registry_fixes[reg] then
+				gkini.WriteString("Neo-registry", "reg" .. tostring(counter), registry_fixes[reg])
+				lib.log_error("patched registration entry for " .. reg .. " >> " .. registry_fixes[reg], 1)
+			end
+		end
+
+		neo.update_check = 1
+		gkini.WriteInt("Neoloader", "update_check", 1)
+	end
 end
 
 RegisterUserCommand("neo", function()

--- a/Neoloader/lang/neomgr/en.ini
+++ b/Neoloader/lang/neomgr/en.ini
@@ -6,7 +6,7 @@
 3=Add a quick access button to the Options menu
 4=Auto-enable mods required by a mod you select to load
 5=neomgr is the bundled management interace for Neoloader. It provides a lightweight interface for configuring Neoloader and managing plugins.
-6=CCD1 Untitled SCM
+6=Untitled Configuration
 7=Close
 8=Apply pending changes
 9=Disabled

--- a/Neoloader/lang/neomgr/es.ini
+++ b/Neoloader/lang/neomgr/es.ini
@@ -6,7 +6,7 @@
 3=Agregar un boton de acceso rapido al menu Opciones
 4=Habilitar automaticamente los mods requeridos por un mod que selecciones para cargar
 5=neomgr es la interfaz de administracion incluida para Neoloader. Proporciona una interfaz liviana para configurar Neoloader y administrar complementos.
-6=CCD1 SCM sin titulo
+6=Configuracion sin titulo
 7=Cerrar
 8=Aplicar cambios pendientes
 9=No cargado

--- a/Neoloader/lang/neomgr/fr.ini
+++ b/Neoloader/lang/neomgr/fr.ini
@@ -6,7 +6,7 @@ Prise en charge de la langue #neomgr
 3=Ajouter un bouton d'acces rapide au menu Options
 4 = Activer automatiquement les mods requis par un mod que vous choisissez de charger
 5=neomgr est l'interface de gestion integree pour Neoloader. Il fournit une interface legere pour configurer Neoloader et gerer les plugins.
-6=CCD1 SCM sans titre
+6=Configuration sans titre
 7=Fermer
 8=Appliquer les modifications en attente
 9=Decharger

--- a/Neoloader/lang/neomgr/pt.ini
+++ b/Neoloader/lang/neomgr/pt.ini
@@ -6,7 +6,7 @@
 3=Adicionar um botao de acesso rapido ao menu Opcoes
 4=Ativar automaticamente mods exigidos por um mod que voce seleciona para carregar
 5=neomgr e a interface de gerenciamento integrada para Neoloader. Ele fornece uma interface leve para configurar o Neoloader e gerenciar plugins.
-6=CCD1 SCM sem titulo
+6=Configuracao sem titulo
 7=Fechar
 8=Aplicar alteracoes pendentes
 9=Nao carregado

--- a/Neoloader/neo_notif.ini
+++ b/Neoloader/neo_notif.ini
@@ -1,8 +1,0 @@
-[modreg]
-API=3
-id=neonotif
-version=1.0.0
-name=Neoloader Notification Handler
-author=Luxen
-website=https://github.com/LuxenDM/Neoloader
-path=neo_notif.lua

--- a/Neoloader/neo_notif.lua
+++ b/Neoloader/neo_notif.lua
@@ -83,7 +83,7 @@ update_class = function()
 		neo[k] = v
 	end
 	
-	lib.set_class("neonotif", "1.0.0", neo)
+	lib.set_class("neonotif", "1.1.0", neo)
 end
 
 local notif_history = {} --notification history

--- a/Neoloader/neo_notif.lua
+++ b/Neoloader/neo_notif.lua
@@ -1,4 +1,13 @@
---Neoloader Default Notification Handler
+--[[
+[modreg]
+API=3
+id=neonotif
+version=1.1.0
+name=Neoloader Notification Handler
+author=Luxen
+website=https://github.com/LuxenDM/Neoloader
+path=neo_notif.lua
+]]--
 
 local cp = function() end --console_print
 
@@ -8,6 +17,8 @@ local bstr = function(id, def)
 	return def
 end
 
+neo.add_translation = function() end --stub until babel is available
+
 local babel_support = function()
 	babel = lib.get_class("babel", "0")
 	
@@ -15,6 +26,10 @@ local babel_support = function()
 	
 	bstr = function(id, def)
 		return babel.fetch(shelf_id, id, def)
+	end
+
+	neo.add_translation = function(path_to_file, file_lang_code)
+		return babel.add_new_lang(shelf_id, path_to_file, file_lang_code)
 	end
 	
 	update_class()

--- a/Neoloader/neomgr.ini
+++ b/Neoloader/neomgr.ini
@@ -1,8 +1,0 @@
-[modreg]
-API=3
-id=neomgr
-name=Neoloader Lightweight Management Interface
-version=2.0.0
-author=Luxen
-website=https://github.com/LuxenDM/Neoloader
-path=neomgr2.lua

--- a/Neoloader/neomgr2.lua
+++ b/Neoloader/neomgr2.lua
@@ -34,6 +34,8 @@ local bstr = function(id, def)
 	return def
 end
 
+neo.add_translation = function() end --stub until babel ready
+
 local babel_support = function()
 	babel = lib.get_class("babel", "0")
 	

--- a/Neoloader/neomgr2.lua
+++ b/Neoloader/neomgr2.lua
@@ -139,7 +139,7 @@ function update_class()
 		neo[k] = v
 	end
 	
-	lib.set_class("neomgr", "2.0.0", neo)
+	lib.set_class("neomgr", "2.1.0", neo)
 end
 
 function neo.auth_key_receiver(new_key)

--- a/Neoloader/neomgr2.lua
+++ b/Neoloader/neomgr2.lua
@@ -291,7 +291,7 @@ local diag_constructor = function()
 	end
 	
 	
-	local create_CCD1_view = function(id, version)
+	neo.create_CCD1_view = function(id, version)
 		--rudimentary CCD1 support
 		
 		cp("creating CCD1 view for " .. tostring(id) .. " v" .. tostring(version))
@@ -522,7 +522,7 @@ local diag_constructor = function()
 								},
 							},
 							iup.label {
-								title = tostring(ctable.title or bstr(6, "CCD1 Untitled SCM")),
+								title = tostring(ctable.title or ("CCD1 " .. bstr(6, "Untitled Configuration"))),
 							},
 							iup.fill {
 								size = "%2",

--- a/Neoloader/neomgr2.lua
+++ b/Neoloader/neomgr2.lua
@@ -1,4 +1,13 @@
---bundled manager for Neoloader, version 2
+--[[
+[modreg]
+API=3
+id=neomgr
+name=Neoloader Lightweight Management Interface
+version=2.1.0
+author=Luxen
+website=https://github.com/LuxenDM/Neoloader
+path=neomgr2.lua
+]]--
 
 
 
@@ -16,7 +25,7 @@ for k, v in ipairs {
 	assert(v, "This version of neomgr is not compatible with the version of Neoloader installed! Please use the version bundled with your latest installation of Neoloader!")
 end
 
-
+local neo = {} --public table
 
 --babel support
 
@@ -32,6 +41,10 @@ local babel_support = function()
 	
 	bstr = function(id, def)
 		return babel.fetch(shelf_id, id, def)
+	end
+
+	neo.add_translation = function(path_to_file, file_lang_code)
+		return babel.add_new_lang(shelf_id, path_to_file, file_lang_code)
 	end
 	
 	update_class()
@@ -67,8 +80,6 @@ local config = {
 		
 	show_debuginfo = gkrs("neomgr", "show_debuginfo", "NO"),
 }
-
-local neo = {}
 
 function update_class()
 	local class = {
@@ -114,7 +125,6 @@ function update_class()
 		},
 		manifest = {
 			"plugins/Neoloader/neomgr2.lua",
-			"plugins/Neoloader/neomgr2.ini",
 			
 			"plugins/Neoloader/lang/en.ini",
 			"plugins/Neoloader/lang/es.ini",
@@ -291,7 +301,7 @@ local diag_constructor = function()
 	end
 	
 	
-	neo.create_CCD1_view = function(id, version)
+	local create_CCD1_view = function(id, version)
 		--rudimentary CCD1 support
 		
 		cp("creating CCD1 view for " .. tostring(id) .. " v" .. tostring(version))
@@ -522,7 +532,7 @@ local diag_constructor = function()
 								},
 							},
 							iup.label {
-								title = tostring(ctable.title or ("CCD1 " .. bstr(6, "Untitled Configuration"))),
+								title = tostring(ctable.title or bstr(6, "CCD1 Untitled SCM")),
 							},
 							iup.fill {
 								size = "%2",

--- a/Neoloader/recovery.lua
+++ b/Neoloader/recovery.lua
@@ -174,7 +174,7 @@ local uninstall_neoloader = function()
 		"rPresortedList",
 		"rPortectResolveFile",
 		"iDbgIgnoreLevel",
-		"rClearCOmmands",
+		"rClearCommands",
 		"rDbgFormatting",
 		"rOverrideDisabledState",
 		"current_notif",

--- a/Neoloader/setup.lua
+++ b/Neoloader/setup.lua
@@ -29,7 +29,7 @@ gkwi("Neoloader", "Init", 3)
 gkws("Neoloader", "mgr", "neomgr")
 gkws("Neoloader", "current_notif", "neonotif")
 gkws("Neoloader", "uninstalled", "NO")
-gkwi("Neoloader", "update_check", 1)
+gkwi("Neoloader", "iUpdateCheck", 1)
 
 local counter = 1
 while true do

--- a/Neoloader/setup.lua
+++ b/Neoloader/setup.lua
@@ -52,8 +52,8 @@ local register_plugin = function(id, version, ini, state)
 	cp("	plugin located in registry at position " .. tostring(plugin_counter))
 end
 
-register_plugin("neomgr", "2.0.0", "plugins/Neoloader/neomgr.ini", "YES")
-register_plugin("neonotif", "1.0.0", "plugins/Neoloader/neo_notif.ini", "YES")
+register_plugin("neomgr", "2.1.0", "plugins/Neoloader/neomgr.lua", "YES")
+register_plugin("neonotif", "1.1.0", "plugins/Neoloader/neo_notif.lua", "YES")
 
 
 

--- a/Neoloader/setup.lua
+++ b/Neoloader/setup.lua
@@ -29,6 +29,7 @@ gkwi("Neoloader", "Init", 3)
 gkws("Neoloader", "mgr", "neomgr")
 gkws("Neoloader", "current_notif", "neonotif")
 gkws("Neoloader", "uninstalled", "NO")
+gkwi("Neoloader", "update_check", 1)
 
 local counter = 1
 while true do

--- a/Neoloader/setup.lua
+++ b/Neoloader/setup.lua
@@ -52,7 +52,7 @@ local register_plugin = function(id, version, ini, state)
 	cp("	plugin located in registry at position " .. tostring(plugin_counter))
 end
 
-register_plugin("neomgr", "2.1.0", "plugins/Neoloader/neomgr.lua", "YES")
+register_plugin("neomgr", "2.1.0", "plugins/Neoloader/neomgr2.lua", "YES")
 register_plugin("neonotif", "1.1.0", "plugins/Neoloader/neo_notif.lua", "YES")
 
 


### PR DESCRIPTION
Made the CCD1 viewer part of the public class. Other plugins can then open the config menu directly instead of providing their own config menu. Also adjusted untitled CCD1 title to work better when using Babel.