### PR TITLE
Implement lost changes intended for v6.2.x

### DIFF
--- a/Neoloader/init.lua
+++ b/Neoloader/init.lua
@@ -500,7 +500,7 @@ function lib.build_ini(iniFilePointer)
 		local plugintype = getstr("modreg", "type", "plugin", ifp)
 		local name = getstr("modreg", "name", "UNTITLED: " .. ifp, ifp)
 		local pluginversion = getstr("modreg", "version", "0", ifp)
-		local pluginapi = getint("modreg", "api", 0, ifp)
+		local pluginapi = getint("modreg", "api", 0, ifp) or getint("modreg", "API", 0, ifp)
 		if err_han( pluginapi ~= neo.API and neo.allowBadAPIVersion == "NO" , "lib.build_ini failed; API mismatched. expected " .. tostring(neo.API) .. ", got " .. tostring(pluginapi) ) then
 			lib.log_error("INI Builder failed: API Mismatch!", 1)
 			return false, "API mismatch"

--- a/Neoloader/init.lua
+++ b/Neoloader/init.lua
@@ -91,7 +91,7 @@ local neo = {
 		[3] = 0,
 		[4] = "",
 	},
-	path = "plugins/Neoloader/" --static value here. upcoming v7.x.x can be variable!
+	path = "plugins/Neoloader/", --static value here. upcoming v7.x.x can be variable!
 	log = {},
 	error_flag = false, 
 	plugin_registry = {}, --holds registered plugin details [id .. version]; [id].latest will provide version sstring of latest version for redirect

--- a/Neoloader/init.lua
+++ b/Neoloader/init.lua
@@ -815,6 +815,7 @@ end
 function lib.activate_plugin(id, version, verify_key)
 	id, version = lib.pass_ini_identifier(id, version)
 	local time_start = gk_get_microsecond()
+	local mem_start = get_mem()
 	lib.log_error("attempting activation of " .. tostring(id) .. "." .. tostring(version), 1)
 	if err_han( type(id) ~= "string", "lib.activate_plugin expected a string for its first argument, got " .. type(id) ) then
 		return false, "plugin ID not a string"
@@ -879,6 +880,7 @@ function lib.activate_plugin(id, version, verify_key)
 	modreg.complete = true
 	lib.log_error("Activated plugin " .. plugin_id .. " with Neoloader successfully!", 2, id, version)
 	lib.log_error("[timestat] activation took: " .. tostring(gk_get_microsecond() - time_start), 1, id, version)
+	lib.log_error("[memstat] memory footprint increased by " .. tostring(get_mem() - mem_start), 1, id, version)
 	if (neo.statelock == false) or (neo.allowDelayedLoad == "YES") then
 		if neo.plugin_registry[plugin_id].dependent_freeze < 1 then
 			lib.check_queue()


### PR DESCRIPTION
These changes were stored on a local branch for implementation into v6.2.0; since they were never pushed to the github, the changes were lost during a several-month period before new changes were made on the github directly. These will now be added to the v6.3.0 interim update. Their functionality will be replicated in the upcoming v7.0.0 redesign.